### PR TITLE
Add Loom format support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,11 @@ RUN mamba create -n anndata2ri-env -c conda-forge -c bioconda \
     numpy \
     scipy \
     scanpy \
+    loompy \
     r-base \
+    r-seurat \
+    r-seuratdisk \
+    r-loom \
     bioconductor-singlecellexperiment \
     r-biocmanager \
     jupyter \

--- a/README.md
+++ b/README.md
@@ -1,20 +1,33 @@
 # anndata2sce
-Bash script for converting anndata to single cell experiment
+Bash script for converting anndata to single cell experiment.
 
-# Prequistics: 
+# Prequistics:
 - singularity
 
 # Install:
-for reprducibility, I indluded the Docker file that use to build the image.
-copy the bash file into your working directory and make it excutable 
+For reproducibility, a Dockerfile is provided. Copy the bash file into your working
+directory and make it executable:
 ```
 chmod +x run_converter.sh
 ```
-in order to launch the script you need to provide the input (H5AD file) as the first argument, and the output (rds file ) as the second argument. \
+The script requires an input `.h5ad` file and an output file path. By default the
+output is a `SingleCellExperiment` RDS file, but other formats can be selected via
+`--format`.
 
-**code example**
+**Code example**
 ```
-./run_converter.sh h5ad_input_path rds_output_file
-```
-till now **08.07.2025** no exception handling is provided. 
+# SingleCellExperiment output
+./run_converter.sh h5ad_input_path sce_output.rds
 
+# Loom output using the Python writer
+./run_converter.sh --format loom h5ad_input_path output.loom
+
+# Loom output through R/Seurat (requires SeuratDisk)
+./run_converter.sh --format loom h5ad_input_path output.loom --use-r
+```
+
+Loom support relies on either the `loompy` Python package or the R packages
+`Seurat` and `SeuratDisk` (installed via the Dockerfile). Ensure these dependencies
+are available when running outside the provided container.
+
+Till now **08.07.2025** no exception handling is provided.

--- a/converter.py
+++ b/converter.py
@@ -1,25 +1,61 @@
-# convert.py
-import sys
+"""Convert AnnData files into other single-cell formats."""
+
+import argparse
 import scanpy as sc
 import anndata2ri
 import rpy2.robjects as ro
 from rpy2.robjects import pandas2ri
 
-# Input arguments
-input_file = sys.argv[1]
-output_file = sys.argv[2]
 
-# Activate bridges
-anndata2ri.activate()
-pandas2ri.activate()
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("input", help="Input AnnData .h5ad file")
+    parser.add_argument("output", help="Output file path")
+    parser.add_argument(
+        "--format",
+        choices=["sce", "loom"],
+        default="sce",
+        help="Output format",
+    )
+    parser.add_argument(
+        "--use-r",
+        action="store_true",
+        help="Use an R-based conversion route when supported",
+    )
+    args = parser.parse_args()
 
-# Load AnnData
-adata = sc.read_h5ad(input_file)
+    # Activate bridges
+    anndata2ri.activate()
+    pandas2ri.activate()
 
-# Push into R and save as SingleCellExperiment
-ro.globalenv["adata"] = adata
-ro.r(f'''
-library(SingleCellExperiment)
-sce <- adata
-saveRDS(sce, file="{output_file}")
-''')
+    # Load AnnData
+    adata = sc.read_h5ad(args.input)
+
+    if args.format == "sce":
+        ro.globalenv["adata"] = adata
+        ro.r(
+            f"""
+            library(SingleCellExperiment)
+            sce <- adata
+            saveRDS(sce, file="{args.output}")
+            """
+        )
+    elif args.format == "loom":
+        if args.use_r:
+            ro.globalenv["adata"] = adata
+            ro.r(
+                f"""
+                library(Seurat)
+                seu <- as.Seurat(adata)
+                library(SeuratDisk)
+                as.loom(seu, filename="{args.output}")
+                """
+            )
+        else:
+            adata.write_loom(args.output)
+    else:
+        raise ValueError(f"Unsupported format: {args.format}")
+
+
+if __name__ == "__main__":
+    main()

--- a/run_converter.sh
+++ b/run_converter.sh
@@ -1,11 +1,33 @@
 IMG="docker://mazenkhaddour/scrnaseq:anndata"
+FORMAT="sce"
+USE_R=""
+
+while [[ "$1" == --* ]]; do
+    case "$1" in
+        --format)
+            FORMAT="$2"
+            shift 2
+            ;;
+        --use-r)
+            USE_R="--use-r"
+            shift
+            ;;
+        *)
+            echo "Unknown option: $1" >&2
+            exit 1
+            ;;
+    esac
+done
+
 INPUT=$1
 OUTPUT=$2
-if [ -z "$INPUT" ]; then
-    echo "Usage: $0 <input_file>"
+if [ -z "$INPUT" ] || [ -z "$OUTPUT" ]; then
+    echo "Usage: $0 [--format FORMAT] [--use-r] <input_file> <output_file>" >&2
     exit 1
 fi
 
 singularity exec -B "$(pwd)" -B /group/testa --cleanenv $IMG python /app/convert.py \
      "$INPUT" \
-     "$OUTPUT"
+     "$OUTPUT" \
+     --format "$FORMAT" \
+     $USE_R


### PR DESCRIPTION
## Summary
- add --format with Loom option and optional R-based route in converter
- install loom dependencies in Dockerfile
- allow run_converter.sh to forward --format/--use-r and document Loom usage

## Testing
- `python -m py_compile converter.py`
- `python converter.py -h` *(fails: ModuleNotFoundError: No module named 'scanpy')*
- `pip install scanpy anndata2ri rpy2` *(fails: Tunnel connection failed: 403 Forbidden)*
- `bash -n run_converter.sh`


------
https://chatgpt.com/codex/tasks/task_e_68af0acb6668832cad92dd4f6cba96cd